### PR TITLE
Use DNS verification on all domains.

### DIFF
--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -10,4 +10,7 @@ civicactions.com:80 www.civicactions.com:80 www.civicactions.com:443 {
 	# Redirect all other domains/ports to the canonical one.
 	redir https://civicactions.com{uri}
 	header / Strict-Transport-Security "max-age=31536000;"
+	tls ca-home@lists.civicactions.net {
+		dns cloudflare
+	}
 }


### PR DESCRIPTION
This is done to avoid fallback to HTTP verification which fails when CloudFlare is enabled causing Caddy to fail to start.