### PR TITLE
Move to external caddy build.

### DIFF
--- a/Caddyfile.defaults
+++ b/Caddyfile.defaults
@@ -12,8 +12,8 @@ header /static {
   Cache-Control "public, max-age=31536000, immutable"
 }
 # The below is not exactly optimal, but caddy can't do headers per-file-ext currently.
-#expires {
-#    match .css$ 1y # expires in 1 year
-#    match .js$ 1y # expires in 1 year
-#    match sw.js$ 1i # expires in 1 second
-#}
+expires {
+    match .css$ 1y # expires in 1 year
+    match .js$ 1y # expires in 1 year
+    match sw.js$ 1i # expires in 1 second
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN /caesiumbin/entrypoint.sh
 #
 # Package site into web server
 #
-FROM civicactions/caddy-docker-build:latest
+FROM civicactions/caddy-docker-build:v1.0.3.2
 
 ENV ENV dev
 
@@ -55,5 +55,3 @@ COPY Caddyfile* /etc/
 
 # Install application from appzz stage.
 COPY --from=appzz /caesium /srv
-
-CMD ["--conf", "/etc/Caddyfile", "--log", "stdout", "--agree=true"]


### PR DESCRIPTION
Caddy managed at https://github.com/CivicActions/caddy-docker-build to improve stability and build times