### PR TITLE
Fix audio pronunciation

### DIFF
--- a/src/components/header/Hero.js
+++ b/src/components/header/Hero.js
@@ -89,10 +89,7 @@ const Hero = ({
     } else if (pronunciation && audioFile) {
       return (
         <div className="hero__personal_pronouns">
-          <span class="text">
-            [{pronunciation}]
-          </span>{" "}
-          {mp3}
+          <span class="text">[{pronunciation}]</span> {mp3}
         </div>
       )
     } else if (personal_pronouns && pronunciation) {

--- a/src/components/header/Hero.js
+++ b/src/components/header/Hero.js
@@ -40,8 +40,8 @@ const Hero = ({
   }
 
   function getPronoun(personal_pronouns, pronunciation, audioFile) {
-    if (personal_pronouns && pronunciation && audioFile) {
-      const mp3 = audioFile ? (
+    if (audioFile) {
+      var mp3 = audioFile ? (
         <div class="audio-wrapper">
           <audio
             src={audioFile["publicURL"]}
@@ -75,11 +75,22 @@ const Hero = ({
           </div>
         </div>
       ) : null
+    }
 
+    if (personal_pronouns && pronunciation && audioFile) {
       return (
         <div className="hero__personal_pronouns">
           <span class="text">
             {personal_pronouns}, [{pronunciation}]
+          </span>{" "}
+          {mp3}
+        </div>
+      )
+    } else if (pronunciation && audioFile) {
+      return (
+        <div className="hero__personal_pronouns">
+          <span class="text">
+            [{pronunciation}]
           </span>{" "}
           {mp3}
         </div>


### PR DESCRIPTION
Issue: audio pronunciation button not appearing on team member's page when team member's personal pronouns are absent

Fix: set button to appear even when personal pronouns are absent